### PR TITLE
feat: add POST /project/budget and tests

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -19,6 +19,36 @@ function validateProjectId (id) {
   return projectId
 }
 
+function validateProjectInput (body) {
+  const requiredFields = [
+    'projectId',
+    'projectName',
+    'year',
+    'currency',
+    'initialBudgetLocal',
+    'budgetUsd',
+    'initialScheduleEstimateMonths',
+    'adjustedScheduleEstimateMonths',
+    'contingencyRate',
+    'escalationRate',
+    'finalBudgetUsd'
+  ]
+
+  const missing = requiredFields.filter(field => body[field] === undefined)
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required fields: ${missing.join(', ')}`)
+  }
+
+  if (typeof body.projectId !== 'number') {
+    throw new Error('projectId must be a number')
+  }
+
+  if (typeof body.year !== 'number') {
+    throw new Error('year must be a number')
+  }
+}
+
 endpoints.get('/ok', (req, res) => {
   res.status(200).json({ ok: true })
 })
@@ -44,6 +74,57 @@ endpoints.get('/project/budget/:id', (req, res) => {
       error: error.message
     })
   }
+})
+
+endpoints.post('/project/budget', (req, res) => {
+  const body = req.body
+
+  try {
+    validateProjectInput(body)
+  } catch (err) {
+    return res.status(400).json({
+      success: false,
+      error: err.message
+    })
+  }
+
+  const checkQuery = 'SELECT projectId FROM project WHERE projectId = ?'
+  executeQuery(checkQuery, [body.projectId])
+    .then(results => {
+      if (results.length > 0) {
+        return res.status(409).json({
+          success: false,
+          error: 'Project with this ID already exists'
+        })
+      }
+
+      const insertQuery = `
+        INSERT INTO project (
+          projectId, projectName, year, currency, initialBudgetLocal,
+          budgetUsd, initialScheduleEstimateMonths, adjustedScheduleEstimateMonths,
+          contingencyRate, escalationRate, finalBudgetUsd
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+
+      const values = [
+        body.projectId, body.projectName, body.year, body.currency,
+        body.initialBudgetLocal, body.budgetUsd,
+        body.initialScheduleEstimateMonths, body.adjustedScheduleEstimateMonths,
+        body.contingencyRate, body.escalationRate, body.finalBudgetUsd
+      ]
+
+      return executeQuery(insertQuery, values).then(() => {
+        res.status(201).json({
+          success: true,
+          message: 'Project created successfully',
+          projectId: body.projectId
+        })
+      })
+    })
+    .catch(err => {
+      console.error(err)
+      res.status(500).json({ success: false, error: 'Internal server error' })
+    })
 })
 
 module.exports = endpoints

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -84,6 +84,129 @@ test('GET /api/project/budget/:id should return full project data structure', fu
   })
 })
 
+test('POST /api/project/budget should return 201', function (t) {
+  const opts = {
+    encoding: 'json',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const data = {
+    projectId: 10001,
+    projectName: 'Humitas Hewlett Packard',
+    year: 2024,
+    currency: 'EUR',
+    initialBudgetLocal: 316974.5,
+    budgetUsd: 233724.23,
+    initialScheduleEstimateMonths: 13,
+    adjustedScheduleEstimateMonths: 12,
+    contingencyRate: 2.19,
+    escalationRate: 3.46,
+    finalBudgetUsd: 247106.75
+  }
+
+  servertest(server, '/api/project/budget', opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 201, 'Should return 201')
+    t.end()
+  }).end(JSON.stringify(data))
+})
+
+test('POST /api/project/budget should return 400 if required fields are missing', function (t) {
+  const opts = {
+    encoding: 'json',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const invalidData = {
+    projectId: 10002,
+    // Missing projectName
+    year: 2024,
+    currency: 'EUR',
+    initialBudgetLocal: 1000,
+    budgetUsd: 900,
+    initialScheduleEstimateMonths: 6,
+    adjustedScheduleEstimateMonths: 5,
+    contingencyRate: 1.2,
+    escalationRate: 1.3,
+    finalBudgetUsd: 950
+  }
+
+  servertest(server, '/api/project/budget', opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 400, 'Should return 400 for missing field')
+    t.ok(res.body && res.body.error, 'Should return error message')
+    t.end()
+  }).end(JSON.stringify(invalidData))
+})
+
+test('POST /api/project/budget should return 409 for duplicate projectId', function (t) {
+  const opts = {
+    encoding: 'json',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const duplicateData = {
+    projectId: 10001, // Already used in previous test
+    projectName: 'Duplicate Test Project',
+    year: 2025,
+    currency: 'USD',
+    initialBudgetLocal: 5000,
+    budgetUsd: 5000,
+    initialScheduleEstimateMonths: 6,
+    adjustedScheduleEstimateMonths: 6,
+    contingencyRate: 0,
+    escalationRate: 0,
+    finalBudgetUsd: 5000
+  }
+
+  servertest(server, '/api/project/budget', opts, function (err, res) {
+    t.error(err, 'No error')
+    t.ok(res.statusCode === 409 || res.statusCode === 400, 'Should return 409 or 400 for duplicate ID')
+    t.ok(res.body && res.body.error, 'Should return error message')
+    t.end()
+  }).end(JSON.stringify(duplicateData))
+})
+
+test('POST /api/project/budget should return 400 for invalid field type', function (t) {
+  const opts = {
+    encoding: 'json',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const invalidTypeData = {
+    projectId: 'not-a-number', // Invalid type
+    projectName: 'Invalid Type Project',
+    year: 2024,
+    currency: 'EUR',
+    initialBudgetLocal: 1000,
+    budgetUsd: 900,
+    initialScheduleEstimateMonths: 6,
+    adjustedScheduleEstimateMonths: 5,
+    contingencyRate: 1.2,
+    escalationRate: 1.3,
+    finalBudgetUsd: 950
+  }
+
+  servertest(server, '/api/project/budget', opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 400, 'Should return 400 for invalid projectId type')
+    t.ok(res.body && res.body.error, 'Should return error message')
+    t.end()
+  }).end(JSON.stringify(invalidTypeData))
+})
+
 test.onFinish(() => {
   if (db.close) db.close()
   process.exit(0)


### PR DESCRIPTION
[Closes #3](https://github.com/Ali-Haider-Tamba-SE/challenge-project-budget-conversion/issues/6)

Implements POST /api/project/budget to add a new project budget to the database.

Includes:
- Validation for all required fields
- Type checks for numeric fields like projectId and year
- Duplicate projectId handling
- Tests for:
  - Successful insert (201)
  - Missing fields (400)
  - Invalid projectId type (400)
  - Duplicate projectId (409)