### PR TITLE
feat: add DELETE /project/budget/:id and tests

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -190,4 +190,34 @@ endpoints.put('/project/budget/:id', (req, res) => {
   }
 })
 
+endpoints.delete('/project/budget/:id', (req, res) => {
+  try {
+    const projectId = validateProjectId(req.params.id)
+    const checkQuery = 'SELECT projectId FROM project WHERE projectId = ?'
+
+    executeQuery(checkQuery, [projectId]).then(results => {
+      if (results.length === 0) {
+        return res.status(404).json({
+          success: false,
+          error: 'Project not found'
+        })
+      }
+
+      const deleteQuery = 'DELETE FROM project WHERE projectId = ?'
+      executeQuery(deleteQuery, [projectId]).then(() => {
+        res.status(200).json({
+          success: true,
+          message: 'Project deleted successfully',
+          projectId
+        })
+      })
+    })
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      error: error.message
+    })
+  }
+})
+
 module.exports = endpoints

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -330,6 +330,50 @@ test('PUT /api/project/budget/:id should return 400 if required fields are missi
   }).end(JSON.stringify(invalidData))
 })
 
+test('DELETE /api/project/budget/:id should return 200', function (t) {
+  const projectId = '10001'
+  const opts = {
+    encoding: 'json',
+    method: 'DELETE'
+  }
+
+  servertest(server, `/api/project/budget/${projectId}`, opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 200, 'Should return 200')
+    t.end()
+  })
+})
+
+test('DELETE /api/project/budget/:id should return 404 if project does not exist', function (t) {
+  const projectId = '999999' // Assumed non-existent
+  const opts = {
+    encoding: 'json',
+    method: 'DELETE'
+  }
+
+  servertest(server, `/api/project/budget/${projectId}`, opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 404, 'Should return 404 for nonexistent project')
+    t.ok(res.body && res.body.error, 'Should return error message')
+    t.end()
+  })
+})
+
+test('DELETE /api/project/budget/:id should return 400 for invalid projectId format', function (t) {
+  const projectId = 'invalid-id' // Not a number
+  const opts = {
+    encoding: 'json',
+    method: 'DELETE'
+  }
+
+  servertest(server, `/api/project/budget/${projectId}`, opts, function (err, res) {
+    t.error(err, 'No error')
+    t.equal(res.statusCode, 400, 'Should return 400 for invalid ID format')
+    t.ok(res.body && res.body.error, 'Should return error message')
+    t.end()
+  })
+})
+
 test.onFinish(() => {
   if (db.close) db.close()
   process.exit(0)


### PR DESCRIPTION
[Closes #5](https://github.com/Ali-Haider-Tamba-SE/challenge-project-budget-conversion/issues/10)

Implements DELETE /api/project/budget/:id to remove a project budget from the database.

Includes:
- projectId format validation
- 404 response if project does not exist
- 400 response for invalid projectId format
- Tests for:
  - Successful deletion (200)
  - Invalid ID format (400)
  - Nonexistent project (404)