### PR TITLE
feat: implement /api-conversion endpoint and tests

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -295,4 +295,93 @@ endpoints.post('/project/budget/currency', async (req, res) => {
   }
 })
 
+endpoints.post('/api-conversion', async (req, res) => {
+  const { projectName, year } = req.body
+
+  // Validate required fields
+  if (!projectName || !year) {
+    return res.status(400).json({
+      success: false,
+      error: 'Missing required fields: projectName, year'
+    })
+  }
+
+  if (typeof year !== 'number') {
+    return res.status(400).json({
+      success: false,
+      error: 'Invalid type: year must be a number'
+    })
+  }
+
+  // Only allow TTD conversion for these projects
+  const allowedProjects = [
+    'Peking roasted duck Chanel',
+    'Choucroute Cartier',
+    'Rigua Nintendo',
+    'Llapingacho Instagram'
+  ]
+
+  if (!allowedProjects.includes(projectName)) {
+    return res.status(403).json({
+      success: false,
+      error: 'Currency conversion to TTD is not allowed for this project'
+    })
+  }
+
+  // Search for the project
+  const searchQuery = 'SELECT * FROM project WHERE projectName LIKE ? AND year = ?'
+  const searchPattern = `%${projectName}%`
+
+  try {
+    executeQuery(searchQuery, [searchPattern, year]).then(async results => {
+      if (results.length === 0) {
+        return res.status(404).json({
+          success: false,
+          error: 'No projects found matching the criteria'
+        })
+      }
+
+      const convertedProjects = []
+
+      for (const project of results) {
+        try {
+          const usdRate = await getExchangeRate('USD', 'TTD')
+          const rate = await getExchangeRate(project.currency, 'TTD')
+
+          const budgetTtd = project.budgetUsd * usdRate
+          const finalBudgetTtd = project.finalBudgetUsd * usdRate
+          const initialBudgetTtd = project.initialBudgetLocal * rate
+
+          convertedProjects.push({
+            ...project,
+            budgetTtd: parseFloat(budgetTtd.toFixed(2)),
+            finalBudgetTtd: parseFloat(finalBudgetTtd.toFixed(2)),
+            initialBudgetTtd: parseFloat(initialBudgetTtd.toFixed(2))
+          })
+        } catch (error) {
+          console.error('Currency conversion error:', error)
+          convertedProjects.push({
+            ...project,
+            budgetTtd: null,
+            finalBudgetTtd: null,
+            initialBudgetTtd: null,
+            conversionError: error.message
+          })
+        }
+      }
+
+      res.status(200).json({
+        success: true,
+        data: convertedProjects
+      })
+    })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({
+      success: false,
+      error: 'Internal server error'
+    })
+  }
+})
+
 module.exports = endpoints


### PR DESCRIPTION
[Closes #8](https://github.com/Ali-Haider-Tamba-SE/challenge-project-budget-conversion/issues/14)

Implements the `/api-conversion` endpoint to convert all currency-related fields of specific projects to TTD.

### Included Features:
- Converts the following values to TTD:
  - `initialBudgetLocal` → `initialBudgetTtd`
  - `budgetUsd` → `budgetTtd`
  - `finalBudgetUsd` → `finalBudgetTtd`
- Applies only to the following allowed projects:
  - Peking roasted duck Chanel
  - Choucroute Cartier
  - Rigua Nintendo
  - Llapingacho Instagram
- Uses real-time exchange rates via exchangerate-api

### Validations:
- Required fields: `projectName`, `year`
- `year` must be a number
- Project must be in the allowed list

### Tests:
- Valid project returns all converted TTD values
- Missing fields return 400
- Invalid year type returns 400
- Unapproved project returns 403
- No matching project returns 404
